### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/GameServiceAPI/template.yaml
+++ b/GameServiceAPI/template.yaml
@@ -127,7 +127,7 @@ Resources:
     Properties:
       CodeUri: gameservice/
       Handler: requestmatchmaking.requestMatchMaking
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - !Ref GameLiftAccessPolicy
         - !Ref DynamoDBAccessPolicy
@@ -143,7 +143,7 @@ Resources:
     Properties:
       CodeUri: gameservice/
       Handler: requestmatchstatus.requestMatchStatus
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - !Ref GameLiftAccessPolicy
         - !Ref DynamoDBAccessPolicy
@@ -160,7 +160,7 @@ Resources:
     Properties:
       CodeUri: gameservice/
       Handler: processmatchmakingevents.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - !Ref DynamoDBAccessPolicy
       Events:
@@ -176,7 +176,7 @@ Resources:
     Properties:
       CodeUri: gameservice/
       Handler: requestgamesession.requestGameSession
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - !Ref GameLiftAccessPolicy
         - !Ref DynamoDBAccessPolicy


### PR DESCRIPTION
CloudFormation templates in aws-gamelift-and-serverless-backend-sample have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.